### PR TITLE
Suggested updates based on my experience building the robot.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,22 +4,26 @@ Raspberry Pi powered mecanum robot
 ## Requirements
 Software to control a 4-wheel mecanum robot. Based on a Raspberry Pi (such as Raspberry Pi Pico W) with two pairs of TB6612FNG motor drivers. Uses keypad controls, also compatible with AntiMicroX or QJoyPad for gamepad control. A graphical version using Pygame Zero is also included.
 
+The new Bookworm version of Raspberry Pi OS is NOT compatible with this install. Load the "Legacy" Bullseye version of the OS.
+
 ## Install and run
 Download the file mecanum.py. It is recommended that this is installed in /opt/mecanum
 Create directory and copy the files using
     sudo mkdir /opt/mecanum
-    sudo chown $USER:
-    cp mecanum.py /opt/mecanum/
+    sudo chown $USER: /opt/mecanum
+    cp mecanum.py /opt/mecanum/ 
     cp robot.sh /opt/mecanum/
+    cd /opt/mecanum
+    chmod u+x mecanum.py
+    chmod u+x robot.sh
     
 Run using
     /opt/robot/mecanum.py
-
 Use the keypad to set the direction.
 
 ## Using AntiMicroX / QJoyPad
 
-Configuration files are included for AnitMicroX and QJoyPad allowing the robot to be controlled with a gamepad controller. 
+Configuration files are included for AntiMicroX and QJoyPad allowing the robot to be controlled with a gamepad controller. 
 
 QJoyPad has not been updated for a long time, so AntiMicroX is recommended.
 Install using 
@@ -28,6 +32,8 @@ Install using
 The following files are included:
 * mecanum.gamecontroller.amgp - AntiMicroX
 * mecanum-gamepad.lyt - QJoyPad
+Download the file to the /opt/mecanum folder.
+From within AntiMicroX, load the file, make any desired changes, and save it. That file will then automatically be loaded when AntiMicroX starts.
 
 There appears to be a conflict, possibly with VNC. If the gamepad is not detected correctly then trying removing and reinserting the USB dongle once or twice and then choosing "Update Joysticks" from the menu.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Raspberry Pi powered mecanum robot
 ## Requirements
 Software to control a 4-wheel mecanum robot. Based on a Raspberry Pi (such as Raspberry Pi Pico W) with two pairs of TB6612FNG motor drivers. Uses keypad controls, also compatible with AntiMicroX or QJoyPad for gamepad control. A graphical version using Pygame Zero is also included.
 
-The new Bookworm version of Raspberry Pi OS is NOT compatible with this install. Load the "Legacy" Bullseye version of the OS.
+The new Bookworm version of Raspberry Pi OS is NOT compatible with this install. It works if you download the "Legacy" Bullseye version of the OS.
 
 ## Install and run
 Download the file mecanum.py. It is recommended that this is installed in /opt/mecanum

--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ The new Bookworm version of Raspberry Pi OS is NOT compatible with this install.
 ## Install and run
 Download the file mecanum.py. It is recommended that this is installed in /opt/mecanum
 Create directory and copy the files using:
+
     sudo mkdir /opt/mecanum
+    
     sudo chown $USER: /opt/mecanum
     
     cp mecanum.py /opt/mecanum/ 
     cp robot.sh /opt/mecanum/
+    
     cd /opt/mecanum
     chmod u+x mecanum.py
     chmod u+x robot.sh

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ The new Bookworm version of Raspberry Pi OS is NOT compatible with this install.
 
 ## Install and run
 Download the file mecanum.py. It is recommended that this is installed in /opt/mecanum
-Create directory and copy the files using
+Create directory and copy the files using:
     sudo mkdir /opt/mecanum
     sudo chown $USER: /opt/mecanum
+    
     cp mecanum.py /opt/mecanum/ 
     cp robot.sh /opt/mecanum/
     cd /opt/mecanum

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ The programs can be started by adding the following entry to /etc/xdg/lxsession/
 
     lxterminal -e /opt/mecanum/robot.sh
 
+## Additional notes
+I noticed the battery pack drains quickly, causing the Raspberry Pi to shut down. My solution is to remove the diode and instead supply the Pi, via its normal power input, with its own 5-volt battery pack. Then the 6-volt battery pack can be dedicated to the motor driver boards.  The two power supplies should have a common ground connection.
 
 ## Pygame Zero version
 There is also a version designed for Pygame Zero. This includes a distance sensor and stops forward motion if a crash is imminent. The interface allows for mouse clicks on the direction arrows or the same keyboard control as the command line version. This also needs pigpiod to be running. To run use

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Create directory and copy the files using:
     
 Run using
     /opt/robot/mecanum.py
+
 Use the keypad to set the direction.
 
 ## Using AntiMicroX / QJoyPad
@@ -36,6 +37,7 @@ Install using
 The following files are included:
 * mecanum.gamecontroller.amgp - AntiMicroX
 * mecanum-gamepad.lyt - QJoyPad
+
 Download the file to the /opt/mecanum folder.
 From within AntiMicroX, load the file, make any desired changes, and save it. That file will then automatically be loaded when AntiMicroX starts.
 
@@ -43,6 +45,7 @@ There appears to be a conflict, possibly with VNC. If the gamepad is not detecte
 
 ## Starting automatically
 The programs can be started by adding the following entry to /etc/xdg/lxsession/LXDE-pi/autostart (edit using sudo)
+
     lxterminal -e /opt/mecanum/robot.sh
 
 

--- a/mecanum.py
+++ b/mecanum.py
@@ -70,7 +70,7 @@ while True:
     # Get next key pressed      
     ch = getch()
 
-    if (ch == 'q') :        # Quit
+    if (ch == 'p' or ch == 'P') :        # Quit
         break
     elif (ch == '+') :      # Change speed
         speed += 10

--- a/robot.sh
+++ b/robot.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # 10s delay to give desktop chance to fully start
 sleep 10s
+cd /opt/mecanum
 antimicrox --tray &
-/opt/mecanum/mecanum.py
+./mecanum.py


### PR DESCRIPTION
These are some suggested updates and work-arounds that I hope would be helpful to others in building the "Raspberry Pi Mecanum Robot" project as described in Issue 135 of the MagPi magazine, and further explained at https://www.penguintutor.com/projects/robot-mecanum . 

-The mecanum.py code was changed to use 'p' or 'P' to exit the program.  It had used 'q', which conflicts with some uses of the WSAD buttons on the keyboard (often mapping 'q' to some action). This is mentioned in the video on the above website. 

-The README file was updated and revised:
This was to fix some formatting errors which mucked up the example Linux code, and to explain the other changes described here.  
Also, it was to suggest using the "Legacy" (Bullseye) version of the Raspberry Pi OS.  When implementing the AntiMicroX software on my Raspberry Pi Zero, I found it would not work with the mecanum.py code. It appears the conflict occurs with the Bookworm version of the RaspPi OS, preventing the mecanum.py process from accessing the joystick device in use by AntiMicroX in another process. My work-around is to install the  "Legacy" Bullseye version of the OS.  Ideally someone will update AntiMicroX, or the RasPi OS, to fix this issue. (I don't know if using Administrator mode may also fix this issue.)

-The Shell program was updated to run from the mecanum folder. In this way the AntiMicroX and mecanum.py programs all run from the same folder that has the configuration file. This also just seems like a cleaner installation.
